### PR TITLE
Annotation services

### DIFF
--- a/reports/management/commands/seedreports.py
+++ b/reports/management/commands/seedreports.py
@@ -9,7 +9,7 @@ from django.db.utils import IntegrityError
 
 from members.services import get_available_reporters
 from reports.models import HappinessReportModel
-from reports.services import get_date_before as get_date
+from reports.utils import get_date_before as get_date
 
 
 class Command(BaseCommand):

--- a/reports/migrations/0001_initial.py
+++ b/reports/migrations/0001_initial.py
@@ -3,7 +3,7 @@ import django.db.models.deletion
 from django.conf import settings
 from django.db import migrations, models
 
-import reports.services
+import reports.utils
 
 
 class Migration(migrations.Migration):
@@ -21,7 +21,7 @@ class Migration(migrations.Migration):
                  models.BigAutoField(auto_created=True, primary_key=True,
                                      serialize=False, verbose_name="ID")),
                 ("reported_on",
-                 models.DateField(default=reports.services.get_today,
+                 models.DateField(default=reports.utils.get_today,
                                   editable=False)),
                 ("level", models.IntegerField(
                     choices=[(1, "Joy"), (2, "Excitement"), (3, "Gratitude"),

--- a/reports/models.py
+++ b/reports/models.py
@@ -6,7 +6,7 @@ from django.contrib.auth import get_user_model
 from django.core.validators import MaxValueValidator, MinValueValidator
 from django.db import models
 
-from reports.services import get_today
+from reports.utils import get_today
 
 
 class HappinessReportModel(models.Model):

--- a/reports/services.py
+++ b/reports/services.py
@@ -2,8 +2,8 @@
 Reports application services
 """
 
-from django.db.models import Avg, F, QuerySet
-from django.db.models.functions import Round
+from django.db.models import Avg, F, QuerySet, Window
+from django.db.models.functions import Lag, Round
 
 from members.models import TeamModel
 from reports.models import HappinessReportModel
@@ -25,7 +25,13 @@ def get_annotated_teams_reports() -> QuerySet:
             "date",
             "team"
         ).annotate(
-            level=Round(Avg("level"))
+            level=Round(Avg("level")),
+        ).annotate(
+            prev=Window(
+                expression=Lag("level"),
+                partition_by="reporter__team",
+                order_by="-reported_on"
+            )
         )
 
 

--- a/reports/services.py
+++ b/reports/services.py
@@ -15,6 +15,9 @@ def get_annotated_teams_reports() -> QuerySet:
     return \
         HappinessReportModel.objects.filter(
             reporter__team__isnull=False
+        ).order_by(
+            "-reported_on",
+            F("reporter__team__name")
         ).annotate(
             date=F("reported_on"),
             team=F("reporter__team__name")

--- a/reports/services.py
+++ b/reports/services.py
@@ -2,18 +2,4 @@
 Reports application services
 """
 
-import datetime
 
-from django.utils import timezone
-
-
-def get_today() -> datetime.date:
-    """Return current date"""
-
-    return timezone.now().date()
-
-
-def get_date_before(days: int) -> datetime.date:
-    """Return date the specified number of days before today"""
-
-    return get_today() - timezone.timedelta(days=days)

--- a/reports/services.py
+++ b/reports/services.py
@@ -2,4 +2,31 @@
 Reports application services
 """
 
+from django.db.models import Avg, F, QuerySet
+from django.db.models.functions import Round
 
+from members.models import TeamModel
+from reports.models import HappinessReportModel
+
+
+def get_annotated_teams_reports() -> QuerySet:
+    """Return an annotated query set with average happiness level"""
+
+    return \
+        HappinessReportModel.objects.filter(
+            reporter__team__isnull=False
+        ).annotate(
+            date=F("reported_on"),
+            team=F("reporter__team__name")
+        ).values(
+            "date",
+            "team"
+        ).annotate(
+            level=Round(Avg("level"))
+        )
+
+
+def get_annotated_team_reports(team: TeamModel) -> QuerySet:
+    """Return an annotated query set for a specific team"""
+
+    return get_annotated_teams_reports().filter(team=team)

--- a/reports/utils.py
+++ b/reports/utils.py
@@ -1,0 +1,19 @@
+"""
+Reports application utilities
+"""
+
+import datetime
+
+from django.utils import timezone
+
+
+def get_today() -> datetime.date:
+    """Return current date"""
+
+    return timezone.now().date()
+
+
+def get_date_before(days: int) -> datetime.date:
+    """Return date the specified number of days before today"""
+
+    return get_today() - timezone.timedelta(days=days)


### PR DESCRIPTION
Annotation services are used to aggregate data for the happiness reports.

Team related services return query sets with an average happiness level per team per date.
Annotated query set also contain previous average happiness level for each team for each date.
This may be used for statistics calculations.
